### PR TITLE
Add properties of second leading lepton to friend tree

### DIFF
--- a/SUSYAnalysis/python/tools/eventVars_1l_base.py
+++ b/SUSYAnalysis/python/tools/eventVars_1l_base.py
@@ -253,6 +253,8 @@ class EventVars1L_base:
             #("tightLeps_DescFlag","I",10,"nTightLeps"),
             'Lep_pdgId','Lep_pt','Lep_eta','Lep_phi','Lep_Idx','Lep_relIso','Lep_miniIso','Lep_hOverE',
             'Selected', # selected (tight) or anti-selected lepton
+            # second leading lepton
+            'Lep2_pt', 'Selected2',
             ## MET
             'MET','LT','ST',
             'MT',
@@ -538,6 +540,12 @@ class EventVars1L_base:
 
             ret['Selected'] = 1
 
+            # Is second leading lepton selected, too?
+            if len(selectedTightLeps) > 1:
+                ret['Selected2'] = 1
+            else:
+                ret['Selected2'] = 0
+
         elif len(antiTightLeps) > 0:
             tightLeps = antiTightLeps
             tightLepsIdx = antiTightLepsIdx
@@ -603,6 +611,10 @@ class EventVars1L_base:
             ret['Lep_miniIso'] = leps[0].miniRelIso
             if hasattr(leps[0],"hOverE"):
                 ret['Lep_hOverE'] = leps[0].hOverE
+
+        # save second leading lepton vars
+        if len(tightLeps) > 1:
+            ret['Lep2_pt'] = tightLeps[1].pt
 
         ########
         ### Jets


### PR DESCRIPTION
Add the following two variables to friend tree:

- Lep2_pt: pT of second leading lepton (if applicable)
- Selected2: Boolean if second leading lepton passes all selection criteria

The other variables (e.g. Lep2_eta) are omitted on purpose to not blow up the friend tree. These two variables should be enough to define two lepton control/validation regions.