### PR TITLE
ISR reweighting for ttbar

### DIFF
--- a/SUSYAnalysis/python/tools/eventVars_1l_WeightsForSystematics.py
+++ b/SUSYAnalysis/python/tools/eventVars_1l_WeightsForSystematics.py
@@ -6,6 +6,7 @@ ROOT.gROOT.ProcessLine(".L ../python/tools/TTbarPolarization.C+")
 ROOT.gSystem.Load("libFWCoreFWLite.so")
 ROOT.AutoLibraryLoader.enable()
 
+
 def getLV(p4):
     if p4 != None: return ROOT.LorentzVector(p4.Px(),p4.Py(),p4.Pz(),p4.E())
     else: return p4
@@ -145,6 +146,7 @@ class EventVars1LWeightsForSystematics:
             "DilepNJetWeightConstUp", "DilepNJetWeightSlopeUp", "DilepNJetWeightConstDn", "DilepNJetWeightSlopeDn",
             # W polarisation
             "WpolWup","WpolWdown",
+            'nISRtt','nISRttweight','nISRttweightsyst_up', 'nISRttweightsyst_down',
             # PDF related -- Work In Progress
             #"pdfW","pdfW_Up","pdfW_Down",
             # Scale uncertainty
@@ -312,6 +314,36 @@ class EventVars1LWeightsForSystematics:
         ret['GenGGPt'] = GenGGPt
         ret['ISRSigUp' ]  = ISRSigUp
         ret['ISRSigDown'] = ISRSigDown
+
+
+        #implement Moriond17 version
+        # of Ana and Manuels nISR jet reweighting, very similar to eventVars_1l_signal.py
+        print self.sample
+        nISRweight = 1
+        nISRweightsyst_up =  1
+        nISRweightsyst_down = 1
+        if 'TTJets' in self.sample:
+            nISR = 0
+            if hasattr(event,'nIsr'): nISR = event.nIsr
+            nISRforWeights = int(nISR)
+            if nISR > 6:
+                nISRforWeights = 6
+            
+            ret['nISR'] = int(nISR)
+            ISRweights = { 0: 1, 1 : 0.920, 2 : 0.821, 3 : 0.715, 4 : 0.662, 5 : 0.561, 6 : 0.511}
+            ISRweightssyst = { 0: 0.0, 1 : 0.040, 2 : 0.090, 3 : 0.143, 4 : 0.169, 5 : 0.219, 6 : 0.244}
+
+
+            C_ISR = 1.071
+            nISRweight = C_ISR * ISRweights[nISRforWeights]
+            nISRweightsyst_up =  1
+            nISRweightsyst_down = 1
+                    
+        ret['nISRttweight'] = nISRweight
+        ret['nISRttweightsyst_up'] = nISRweightsyst_up 
+        ret['nISRttweightsyst_down'] = nISRweightsyst_down
+        
+        print "weight",nISRweight
         return ret
 
 if __name__ == '__main__':

--- a/SUSYAnalysis/python/tools/eventVars_1l_signal.py
+++ b/SUSYAnalysis/python/tools/eventVars_1l_signal.py
@@ -144,9 +144,14 @@ class EventVars1L_signal:
                 nISRforWeights = 6
 
             ret['nISR'] = int(nISR)
-            ISRweights = { 0: 1, 1 : 0.882, 2 : 0.792, 3 : 0.702, 4 : 0.648, 5 : 0.601, 6 : 0.515}
-            ISRweightssyst = { 0: 0.0, 1 : 0.059, 2 : 0.104, 3 : 0.149, 4 : 0.176, 5 : 0.199, 6 : 0.242}
-
+            #ICHEP weights
+            #ISRweights = { 0: 1, 1 : 0.882, 2 : 0.792, 3 : 0.702, 4 : 0.648, 5 : 0.601, 6 : 0.515}
+            #ISRweightssyst = { 0: 0.0, 1 : 0.059, 2 : 0.104, 3 : 0.149, 4 : 0.176, 5 : 0.199, 6 : 0.242}
+            
+            #Moriond17 weights
+            ISRweights = { 0: 1, 1 : 0.920, 2 : 0.821, 3 : 0.715, 4 : 0.662, 5 : 0.561, 6 : 0.511}
+            ISRweightssyst = { 0: 0.0, 1 : 0.040, 2 : 0.090, 3 : 0.143, 4 : 0.169, 5 : 0.219, 6 : 0.244}
+            
             C_ISR = float(C_ISRweightsSusy[(mGo,mLSP)][0])
             C_ISR_up = float(C_ISRweightsSusy[(mGo,mLSP)][1])
             C_ISR_down = float(C_ISRweightsSusy[(mGo,mLSP)][2])


### PR DESCRIPTION
- same code as for signal (just duplicated for the moment)
- weights updated to Moriond17, for signal ICHEP normalization still used
- ttbar normalization from Moriond17 weights